### PR TITLE
Datastore config column ordering and notice if form field change

### DIFF
--- a/packages/space/package.json
+++ b/packages/space/package.json
@@ -17,6 +17,7 @@
     "react-addons-shallow-compare": "^15.6.2",
     "react-autocomplete": "^1.8.1",
     "react-avatar": "^3.0.2",
+    "react-beautiful-dnd": "^8.0.4",
     "react-dom": "^16.2.0",
     "react-kinetic-core": "^0.6.2",
     "react-redux": "^5.0.7",

--- a/packages/space/src/assets/styles/_datastore.scss
+++ b/packages/space/src/assets/styles/_datastore.scss
@@ -63,31 +63,51 @@
   }
   table.table-datastore {
     font-size: 0.875rem;
-    margin-top: 1.5rem;
 
     tbody {
-      td {
-        > a {
-          font-weight: 600;
-        }
-        > small {
-          color: $gray;
-        }
-        > .list-dropdown {
-          & > button {
-            padding: 0;
-            color: $black-50;
-            &:hover {
-              color: darken($black-50, 5%);
+      tr {
+        td {
+          > a {
+            font-weight: 600;
+          }
+          > small {
+            color: $gray;
+          }
+          > .list-dropdown {
+            & > button {
+              padding: 0;
+              color: $black-50;
+              &:hover {
+                color: darken($black-50, 5%);
+              }
             }
           }
+          > .dropdown .btn {
+            background-color: transparent;
+            padding: 0rem 0.25rem;
+          }
+          & .dropdown-item {
+            padding: 0.25rem 1rem;
+          }
         }
-        > .dropdown .btn {
-          background-color: transparent;
-          padding: 0rem 0.25rem;
-        }
-        & .dropdown-item {
-          padding: 0.25rem 1rem;
+      }
+    }
+
+    &.table-draggable {
+      border-collapse: separate;
+      border-spacing: 0px;
+
+      tbody {
+        tr {
+          &.dragging {
+            background-color: $blue3;
+            td {
+              border: none;
+            }
+            td + td {
+              display: none;
+            }
+          }
         }
       }
     }
@@ -97,6 +117,11 @@
     justify-content: space-between;
     display: flex;
     flex: 1 1 100%;
+    margin: 0 0 0.5rem 0;
+
+    .table-title__wrapper {
+      line-height: 2.25rem;
+    }
   }
 
   @media (min-width: 768px) {

--- a/packages/space/src/records.js
+++ b/packages/space/src/records.js
@@ -56,6 +56,7 @@ export const DatastoreForm = Record({
   description: '',
   indexDefinitions: List(),
   columns: List(),
+  fields: [],
   canManage: false,
   isHidden: false,
   bridgeModel: BridgeModel(),
@@ -85,8 +86,6 @@ export const ColumnConfig = Record({
   type: '',
   // if the column is displayable in the table
   visible: false,
-  // if the column is filterable in the table
-  filterable: false,
 });
 
 export const SearchParams = Record({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@7.0.0-beta.52":
+  version "7.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.52.tgz#3f3b42b82b92b4e1a283fc78df1bb2fd4ba8d0c7"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1808,6 +1815,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1916,6 +1927,10 @@ crypto-browserify@^3.11.0:
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
+css-box-model@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.0.0.tgz#60142814f2b25be00c4aac65ea1a55a531b18922"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -5194,6 +5209,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -6034,6 +6053,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -6535,7 +6558,11 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
-raf@3.4.0, raf@^3.4.0:
+raf-schd@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.0.tgz#9855756c5045ff4ed4516e14a47719387c3c907b"
+
+raf@3.4.0, raf@^3.1.0, raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -6641,6 +6668,20 @@ react-avatar@^3.0.2:
     is-retina "^1.0.3"
     md5 "^2.0.0"
 
+react-beautiful-dnd@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-8.0.4.tgz#d7572913065261d69d6de5b87573ff7ecb9548dd"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.52"
+    css-box-model "^1.0.0"
+    memoize-one "^4.0.0"
+    prop-types "^15.6.1"
+    raf-schd "^4.0.0"
+    react-motion "^0.5.2"
+    react-redux "^5.0.7"
+    redux "^4.0.0"
+    tiny-invariant "^0.0.3"
+
 react-dev-utils@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.1.tgz#1f396e161fe44b595db1b186a40067289bf06613"
@@ -6724,6 +6765,14 @@ react-markdown@^3.2.0:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
+
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
 
 react-popper@^0.8.2, react-popper@^0.8.3:
   version "0.8.3"
@@ -6978,6 +7027,13 @@ redux@^3.6.0, redux@^3.7.2:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
+redux@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+  dependencies:
+    loose-envify "^1.1.0"
+    symbol-observable "^1.2.0"
+
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
@@ -6989,6 +7045,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz#8052ac952d85b10f3425192cd0c53f45cf65c6cb"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -7903,7 +7963,7 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -7991,6 +8051,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-invariant@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-0.0.3.tgz#4c7283c950e290889e9e94f64d3586ec9156cf44"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Updated the datastore config page to allow users to order the columns via drag and drop. Also added a popup notice that appears if the fields in the form are changed and the user has stale data on their config page.