### PR TITLE
Added default search option to datastore config

### DIFF
--- a/packages/space/src/assets/styles/_datastore.scss
+++ b/packages/space/src/assets/styles/_datastore.scss
@@ -16,6 +16,7 @@
 
     .advanced-dropdown-wrapper {
       .index-selector,
+      .direction-selector,
       .index-part {
         display: flex;
         flex-direction: row;

--- a/packages/space/src/assets/styles/_temp.scss
+++ b/packages/space/src/assets/styles/_temp.scss
@@ -86,6 +86,7 @@ textarea {
       margin: 0;
     }
 
+    .direction-selector,
     .index-selector {
       margin-bottom: 1rem;
       align-items: center;

--- a/packages/space/src/components/settings/datastore/DatastoreSettings.js
+++ b/packages/space/src/components/settings/datastore/DatastoreSettings.js
@@ -125,6 +125,74 @@ const SettingsComponent = ({
             <div className="table-settings">
               <h3 className="section__title">Table Display Settings</h3>
               <div className="settings">
+                <div className="form-group">
+                  <label htmlFor="default-search-index">
+                    Default Search Index
+                  </label>
+                  <select
+                    id="default-search-index"
+                    name="default-search-index"
+                    onChange={e => {
+                      handleFormChange(
+                        'defaultSearchIndex',
+                        e.target.value
+                          ? {
+                              index: e.target.value,
+                              direction: 'ASC',
+                            }
+                          : null,
+                      );
+                    }}
+                    value={
+                      (updatedForm.defaultSearchIndex &&
+                        updatedForm.defaultSearchIndex.index) ||
+                      ''
+                    }
+                    className="form-control"
+                  >
+                    <option value="">Don't perform default search</option>
+                    <optgroup label="Search by Index:">
+                      {List(origForm.indexDefinitions)
+                        .filter(d => d.status === 'Built')
+                        .map(({ name }) => (
+                          <option value={name} key={name}>
+                            {name.replace(':UNIQUE', '')}
+                          </option>
+                        ))}
+                    </optgroup>
+                  </select>
+                </div>
+                {updatedForm.defaultSearchIndex && (
+                  <div className="form-group">
+                    <label htmlFor="default-search-direction">
+                      Default Search Sort Direction
+                    </label>
+                    <select
+                      id="default-search-direction"
+                      name="default-search-direction"
+                      onChange={e => {
+                        handleFormChange(
+                          'defaultSearchIndex',
+                          e.target.value
+                            ? {
+                                index: updatedForm.defaultSearchIndex.index,
+                                direction: e.target.value,
+                              }
+                            : null,
+                        );
+                      }}
+                      value={
+                        (updatedForm.defaultSearchIndex &&
+                          updatedForm.defaultSearchIndex.direction) ||
+                        'ASC'
+                      }
+                      className="form-control"
+                    >
+                      <option value="ASC">Ascending</option>
+                      <option value="DESC">Descending</option>
+                    </select>
+                  </div>
+                )}
                 <table className="table table-datastore table-draggable">
                   <thead>
                     <tr className="header">

--- a/packages/space/src/components/settings/datastore/SubmissionSearch/SubmissionList.js
+++ b/packages/space/src/components/settings/datastore/SubmissionSearch/SubmissionList.js
@@ -46,13 +46,13 @@ const sortTable = ({ clientSortInfo, setClientSortInfo }) => column => {
   ) {
     setClientSortInfo({
       ...clientSortInfo,
-      order: clientSortInfo.order === 'DESC' ? 'ASC' : 'DESC',
+      direction: clientSortInfo.direction === 'DESC' ? 'ASC' : 'DESC',
     });
   } else {
     setClientSortInfo({
       type: column.type,
       name: column.name,
-      order: 'ASC',
+      direction: 'ASC',
     });
   }
 };
@@ -75,7 +75,6 @@ const SubmissionListComponent = ({
   sortTable,
 }) => {
   const visibleColumns = columns.filter(c => c.visible);
-  console.log(visibleColumns.toJS());
   return (
     <div className="datastore-submissions">
       {loading ? (
@@ -110,7 +109,7 @@ const SubmissionListComponent = ({
                         (clientSortInfo &&
                           clientSortInfo.type === c.type &&
                           clientSortInfo.name === c.name &&
-                          (clientSortInfo.order === 'DESC'
+                          (clientSortInfo.direction === 'DESC'
                             ? 'sort-desc'
                             : 'sort-asc')) ||
                         '';
@@ -170,12 +169,12 @@ const SubmissionListComponent = ({
                           <select
                             className="form-control"
                             value={
-                              (clientSortInfo && clientSortInfo.order) || ''
+                              (clientSortInfo && clientSortInfo.direction) || ''
                             }
                             onChange={e => {
                               sortTable({
                                 ...clientSortInfo,
-                                order: e.target.value,
+                                direction: e.target.value,
                               });
                             }}
                           >

--- a/packages/space/src/components/settings/datastore/SubmissionSearch/SubmissionSearch.js
+++ b/packages/space/src/components/settings/datastore/SubmissionSearch/SubmissionSearch.js
@@ -56,7 +56,7 @@ const SubmissionSearchComponent = ({
             </Link>
           </div>
         </div>
-        <Searchbar />
+        <Searchbar formSlug={match.params.slug} />
         <Paging />
         <SubmissionList />
       </div>
@@ -72,6 +72,7 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = {
   fetchForm: actions.fetchForm,
+  clearForm: actions.clearForm,
   resetSearch: actions.resetSearchParams,
 };
 
@@ -122,6 +123,9 @@ export const SubmissionSearch = compose(
         csv = 'data:text/csv;charset=utf-8,' + csv;
         nextProps.setData(encodeURI(csv));
       }
+    },
+    componentWillUnmount() {
+      this.props.clearForm();
     },
   }),
 )(SubmissionSearchComponent);

--- a/packages/space/src/records.js
+++ b/packages/space/src/records.js
@@ -56,6 +56,7 @@ export const DatastoreForm = Record({
   description: '',
   indexDefinitions: List(),
   columns: List(),
+  defaultSearchIndex: null,
   fields: [],
   canManage: false,
   isHidden: false,
@@ -74,6 +75,14 @@ export const DatastoreFormSave = Record({
   slug: '',
   description: '',
   attributesMap: {},
+});
+
+// Used in datastore to define configurations
+export const DatastoreConfig = Record({
+  // columns config
+  columns: List(),
+  // index for use in initial search
+  defaultSearchIndex: null,
 });
 
 // Used in datastore to define a single table column

--- a/packages/space/src/redux/sagas/settingsDatastore.js
+++ b/packages/space/src/redux/sagas/settingsDatastore.js
@@ -78,14 +78,20 @@ export function* updateFormSaga() {
 
   const formContent = DatastoreFormSave(currentForm).set('attributesMap', {
     'Datastore Configuration': [
-      JSON.stringify(currentFormChanges.columns.toJS()),
+      JSON.stringify({
+        columns: currentForm.columns.toJS(),
+        defaultSearchIndex: currentForm.defaultSearchIndex,
+      }),
     ],
   });
   const formContentChanges = DatastoreFormSave(currentFormChanges).set(
     'attributesMap',
     {
       'Datastore Configuration': [
-        JSON.stringify(currentFormChanges.columns.toJS()),
+        JSON.stringify({
+          columns: currentFormChanges.columns.toJS(),
+          defaultSearchIndex: currentFormChanges.defaultSearchIndex,
+        }),
       ],
     },
   );
@@ -180,6 +186,7 @@ export const selectSearchParams = state => ({
   simpleSearchParam: state.space.settingsDatastore.simpleSearchParam,
   simpleSearchNextPageIndex:
     state.space.settingsDatastore.simpleSearchNextPageIndex,
+  sortDirection: state.space.settingsDatastore.sortDirection,
 });
 
 export function* fetchSubmissionsSimpleSaga() {
@@ -187,6 +194,7 @@ export function* fetchSubmissionsSimpleSaga() {
     form,
     pageToken,
     simpleSearchParam,
+    sortDirection,
     simpleSearchNextPageIndex,
   } = yield select(selectSearchParams);
 
@@ -197,6 +205,7 @@ export function* fetchSubmissionsSimpleSaga() {
     const query = new CoreAPI.SubmissionSearch(true);
     query.include(SUBMISSION_INCLUDES);
     query.limit(DATASTORE_LIMIT);
+    query.sortDirection(sortDirection === 'DESC' ? sortDirection : 'ASC');
     query.index(index.name);
     query.sw(index.parts[0], simpleSearchParam);
     query.pageToken(pageToken);
@@ -229,6 +238,7 @@ export function* fetchSubmissionsSimpleSaga() {
         const query = new CoreAPI.SubmissionSearch(true);
         query.include(SUBMISSION_INCLUDES);
         query.limit(DATASTORE_LIMIT);
+        query.sortDirection(sortDirection === 'DESC' ? sortDirection : 'ASC');
         query.index(index.name);
         query.sw(index.parts[0], simpleSearchParam);
         return query;
@@ -300,12 +310,15 @@ export function* fetchSubmissionsSimpleSaga() {
 }
 
 export function* fetchSubmissionsAdvancedSaga() {
-  const { searchParams, form, pageToken } = yield select(selectSearchParams);
+  const { searchParams, sortDirection, form, pageToken } = yield select(
+    selectSearchParams,
+  );
 
   const searcher = new CoreAPI.SubmissionSearch(true);
 
   searcher.include(SUBMISSION_INCLUDES);
   searcher.limit(DATASTORE_LIMIT);
+  searcher.sortDirection(sortDirection === 'DESC' ? sortDirection : 'ASC');
   if (pageToken) {
     searcher.pageToken(pageToken);
   }


### PR DESCRIPTION
In the datastore config screen, you can now select a default search index, and that search will be performed when you view the records page.